### PR TITLE
Added some clarification to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Z-Stack-firmware
 This reposistory contains:
 - Compiled Z-Stack firmwares (`.hex` files)
+    - If you want to use these to flash to your CC253X (using the [Flash Programmer (not v2)](http://www.ti.com/tool/FLASH-PROGRAMMER) for example), make sure you save the __`raw`__ file (`.hex` file should be around 600kb when saved, not 3.5mb)
 - Instructions on how to compile them
 
 ### Instructions


### PR DESCRIPTION
Both #2 and #6 mention the `could not open specified HEX file` error. This might be because some people go to [the directory](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/CC2530/bin) containing the hex file on GitHub and do a `save as...` on the link instead of going to the `raw` file.  
Hopefully this will prevent some people from getting this error in the future 😉 