### PR TITLE
Fix link to "What's new in Zigbee 3.0

### DIFF
--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -101,7 +101,7 @@ This depends:
 - *Type:* The source routing firmware allows the coordinator to remember the routes to the devices. Improves performance for larger (40+ nodes) networks. For more information read [Large ZigBee Networks and Source Routing
 ](http://cms.digi.com/resources/documentation/digidocs/90001537/references/r_large_zigbee_networks-source_routing.htm?TocPath=Working%20with%20Zigbee%7C_____14). Because of memory limitations, the number of direct children are reduced for these firmwares.
 - *Device:* The Zigbee hardware
-- *Zigbee:* Zigbee version, for more information read [What's New in Zigbee 3.0](http://www.ti.com/lit/an/swra615/swra615.pdf)
+- *Zigbee:* Zigbee version, for more information read [What's New in Zigbee 3.0](http://www.ti.com/lit/an/swra615a/swra615a.pdf)
 - *Direct children:* Number of children that directly can join the coordinator. Note that this is **not** the maximum network size. For more information, read [the Zigbee2mqtt FAQ about device limit](http://www.zigbee2mqtt.io/information/FAQ.html#i-read-that-zigbee2mqtt-has-a-limit-of-15-devices-is-this-true)
 
 #### Notes


### PR DESCRIPTION
Old white paper file is not available anymore. But version ending with "a" is available - at least right now.