### PR TITLE
Update README.md to also list Z-Stack 3.0.x on CC2538

### DIFF
--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -35,7 +35,7 @@ This repository contains various Z-Stack coordinator firmwares.
     <td></td>
   </tr>
   <tr>
-    <td rowspan="2">Z-Stack_3.0.x</td>
+    <td rowspan="3">Z-Stack_3.0.x</td>
     <td>CC2531</td>
     <td>3.0</td>
     <td>15</td>
@@ -53,6 +53,17 @@ This repository contains various Z-Stack coordinator firmwares.
     <td>40/0</td>
     <td>
       - <a href="https://github.com/Koenkk/zigbee2mqtt/issues/1445">Discussion #1445</a>
+      <br/>
+      - Max 40 Zigbee 3.0 devices
+    </td>
+  </tr>
+    <tr>
+    <td>CC2538 + CC2592</td>
+    <td>3.0</td>
+    <td>15</td>
+    <td>40/0</td>
+    <td>
+      - <a href="https://github.com/Koenkk/zigbee2mqtt/issues/1568">Discussion #1568</a>
       <br/>
       - Max 40 Zigbee 3.0 devices
     </td>

--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -60,8 +60,8 @@ This repository contains various Z-Stack coordinator firmwares.
     <tr>
     <td>CC2538 + CC2592</td>
     <td>3.0</td>
-    <td>15</td>
-    <td>40/0</td>
+    <td>80</td>
+    <td>40/400</td>
     <td>
       - <a href="https://github.com/Koenkk/zigbee2mqtt/issues/1568">Discussion #1568</a>
       <br/>


### PR DESCRIPTION
As per suggestion in https://github.com/Koenkk/Z-Stack-firmware/issues/148 README.md was missing a listing for the newly added support for Z-Stack 3 on CC2538 which was added with https://github.com/Koenkk/Z-Stack-firmware/pull/144 and discussed in https://github.com/Koenkk/zigbee2mqtt/issues/1568

@Koenkk @reverieline Please understand that some information about CC2538 support might still be missing as I note below:

Please note that I am not sure if Z-Stack 3.0.x is only supported on a module with on CC2538 + CC2592 or if it is also supported on modules with only CC2538 without an amplifier chip or a module with CC2538 and the CC2591 amplifier chip? 

I was not either sure about supported Direct children or the max values for total numbers of Zigbee devices supported by CC2538 in the Z-Stack 3.0.x firmware which has now been added?

In addition, please also note that I am not sure if Zigbee 3.0 coordinator is now actually recommended on a CC2538 module as well, or if it is still only recommended on CC26X2R1 and CC1352P_2 so I did not change that line about such recommendation. CC2538 might be powerful enough to be recommended as well or?

PS: @reverieline Off-topic here but I was wondering if a version of Z-Stack 1.2 could be made for CC2538 too based on your FW?