### PR TITLE
Update README.md

### DIFF
--- a/coordinator/Z-Stack_3.x.0/bin/README.md
+++ b/coordinator/Z-Stack_3.x.0/bin/README.md
@@ -92,7 +92,7 @@
     <td>DIO_15</td>
     <td>No</td>
     <td>DIO_5: 20dBm PA<br>DIO_6: 2.4GHz</td>
-    <td>DIO_7 (Green)<br>DIO_8 (Red)<br></td>
+    <td>DIO_8 (Green)<br>DIO_7 (Red)<br></td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Fix LEDs colors on Zigbeer E72 by Egony adapter

As described in my ti_drivers_config.h:
#define CONFIG_PIN_RLED      0x00000007
#define CONFIG_PIN_GLED      0x00000008
