### PR TITLE
Improve formatting in router README

### DIFF
--- a/router/README.md
+++ b/router/README.md
@@ -1,13 +1,13 @@
 # Buttons
 
-The S1 button only changes the state of the green LED. 
-The S2 button repairs CC2531 (see below)
+* S1 button: only changes the state of the green LED. 
+* S2 button: repairs CC2531 (see below)
 
 # Lights
 
-Short fast blinks (one per second) – the router is connecting to a network.
-Short long blinks (one per 4 seconds) – normal operations.
-Three short blinks – the router cannot send a report to a coordinator.
+* Short fast blinks (one per second) – the router is connecting to a network.
+* Short long blinks (one per 4 seconds) – normal operations.
+* Three short blinks – the router cannot send a report to a coordinator.
 
 # Pairing
 
@@ -15,5 +15,5 @@ Flash firmware and permit joining to a network on your coordinator.
 
 # Re-pairing
 
-CC2530, CC2531: Power on, wait 2 seconds, power off, repeat this cycle three times.
-CC2531: Power on, press and hold down the S2 button for 5 seconds.
+* CC2530, CC2531: Power on, wait 2 seconds, power off, repeat this cycle three times.
+* CC2531: Power on, press and hold down the S2 button for 5 seconds.


### PR DESCRIPTION
Just to make things a little more readable so bullet points are separated compared to being a run-on paragraph