### PR TITLE
Updated README.md with Tube's Zigbee PoE Serial Coordinator

### DIFF
--- a/coordinator/Z-Stack_3.x.0/bin/README.md
+++ b/coordinator/Z-Stack_3.x.0/bin/README.md
@@ -106,6 +106,15 @@
     <td>N/A</td>
   </tr>
   <tr>
+    <td>Tube's Zigbee PoE (Power Over Ethernet) Serial Coordinator (CC2652P2 variant)<br></td>
+    <td>CC2652P<br>(RFSTAR RF-BM-2652P2)<br></td>
+    <td>CC1352P2_CC2652P_launchpad_*.zip</td>
+    <td>DIO_15</td>
+    <td>N/A</td>
+    <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
+    <td>N/A</td>
+  </tr>
+  <tr>
     <td>Egony Stick V4<br>(Ebyte ver.)</td>
     <td>CC2652P<br>(Ebyte E72-2G4M20S1E)</td>
     <td>CC1352P2_CC2652P_other_*.zip</td>


### PR DESCRIPTION
Updated README.md with Tube's Zigbee PoE (Power Over Ethernet) Serial Coordinator by @tube0013

https://www.tubeszb.com/product/cc2652_poe_coordinator/15

https://github.com/tube0013/tube_gateways/issues/8

https://twitter.com/TubesZb/status/1394478007730020352

https://twitter.com/TubesZb/status/1394845581823074308