### PR TITLE
initial commit for index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,0 +1,39 @@
+{
+  "index_version":"1631448902",
+  
+  "firmware_type":{
+    "coordinator":{
+      "stack":[
+        {
+          "Z-Stack_3.0.x":"20190523"
+        },
+        {
+          "Z-Stack_3.x.0":"20210708"
+        }
+      ],
+      "stack_default":"Z-Stack_3.x.0"
+    },
+    "router":{
+      "stack":[
+        [
+          "Z-Stack_3.x.0",
+          "20210128"
+        ]
+      ],
+      "stack_default":"Z-Stack_3.x.0"
+    }
+  },
+  
+  "boards":{
+    "LAUNCHXL-CC26xR1":"CC2652R",
+    "LAUNCHXL-CC1352P-2":"CC1352P2_CC2652P_launchpad",
+    "zzh":"CC2652R",
+    "zzhp":"CC1352P2_CC2652P_other",
+    "zzhp-lite":"CC1352P2_CC2652P_other"
+  },
+  
+  "bsl-config":{
+    "CC2652R":"0x00057FD8:0xC50DFEC5",
+    "CC1352P2_CC2652P_launchpad":"0x00057FD8:0xC50FFEC5"
+  }
+}


### PR DESCRIPTION
this introduces `index.json` to the repo, discussed in #310 

format described below:

```
{
  # version of index.json served, epoch timestamp
  "index_version":"1631448902",

  # firmware type -> firmware role -> available stacks (stack name : latest release)
  # download URL: "<repo>/blob/master/{fw_role}/{fw_stack}/bin/{fw-config}-{fw-role}-{fw-release}.zip?raw=true"
  "firmware_type":{
    "coordinator":{
      "stack":[
        {
          "Z-Stack_3.0.x":"20190523"
        },
        {
          "Z-Stack_3.x.0":"20210708"
        }
      ],
      "stack_default":"Z-Stack_3.x.0"
    },
    "router":{
      "stack":[
        [
          "Z-Stack_3.x.0",
          "20210128"
        ]
      ],
      "stack_default":"Z-Stack_3.x.0"
    }
  },

  # board name -> firmware configuration
  "boards":{
    "LAUNCHXL-CC26xR1":"CC2652R",
    "LAUNCHXL-CC1352P-2":"CC1352P2_CC2652P_launchpad",
    "zzh":"CC2652R",
    "zzhp":"CC1352P2_CC2652P_other",
    "zzhp-lite":"CC1352P2_CC2652P_other"
  },
  
  # firmware configuration -> CCFG offset : valid BSL configuration value
  "bsl-config":{
    "CC2652R":"0x00057FD8:0xC50DFEC5",
    "CC1352P2_CC2652P_launchpad":"0x00057FD8:0xC50FFEC5"
  }
}

```

This is meant to be a preview so `boards` and `bsl-config` are not complete. We should probably have a way to generate this index.json automatically, perhaps as part of your release scripts? I'll leave that to your discretion.