### PR TITLE
CC1352P2_CC2652P_launchpad fw for Sonoff Zigbee 3.0 USB Dongle Plus

### DIFF
--- a/coordinator/Z-Stack_3.x.0/bin/README.md
+++ b/coordinator/Z-Stack_3.x.0/bin/README.md
@@ -168,6 +168,15 @@
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_7 (Green)<br>DIO_6 (Red)<br></td>
   </tr>
+  <tr>
+    <td>ITead Sonoff Zigbee 3.0 USB Dongle Plus</td>
+    <td>CC2652P</td>
+    <td>CC1352P2_CC2652P_launchpad_*.zip</td>
+    <td>?</td>
+    <td>?</td>
+    <td>?</td>
+    <td>?</td>
+  </tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
CC1352P2_CC2652P_launchpad fw for ITead Sonoff Zigbee 3.0 USB Dongle Plus.

Zigbee2MQTT discussion here:

https://github.com/Koenkk/zigbee2mqtt/discussions/8840

Disclaimer! Have not tested this myself as I do not have the hardware, and I have no affiliation with ITead and Sonoff or its resellers. 

This is only based on information posted by ITead themselves which refer to using Koenkk Z-Stack-firmware:

https://sonoff.tech/wp-content/uploads/2021/09/Zigbee-3.0-USB-dongle-plus-firmware-flashing-.docx

https://sonoff.tech/product-review/zigbee-3-0-usb-dongle-plus/

https://sonoff.tech/new-product-coming-soon/?fbclid=IwAR2nyXNbxQ2K0-yIx7ccPtG6OAY_6hJkVG6xHwdnRfU23AYvfXFREDagCjQ

https://www.facebook.com/SONOFF.official/posts/2867330886911891

https://www.facebook.com/iteadstudio/posts/4960944183932977

PS: Off-topic but interesting that this documentation also states that this dongle hardware does support Hardware Flow Control but default firmware does not and therefore they have added information on how to enable Hardware Flow Control as an option:

https://sonoff.tech/product-review/zigbee-3-0-usb-dongle-plus/

"The dongle is pre-flashed with the official Zigbee 3.0 coordinator firmware, which does not support software flow control. The dongle supports hardware flow control, if you want to enable it, please set the dip switch to on, and generate the firmware that supports hardware flow control before running, see the following document for details on how to generate the corresponding firmware."

https://sonoff.tech/wp-content/uploads/2021/09/Zigbee-3.0-USB-dongle-plus-firmware-flashing-.docx

Enable hardware flow control and generate firmware (optional) If you need to enable the hardware flow control of the CC2652P USB Dongle, you need to use CCS to import the ZNP project to configure and compile the firmware that supports the hardware flow control.