### PR TITLE
Update README.md add RF and RFS/CTS info on Sonoff

### DIFF
--- a/coordinator/Z-Stack_3.x.0/bin/README.md
+++ b/coordinator/Z-Stack_3.x.0/bin/README.md
@@ -12,6 +12,7 @@
     <th>Auto-BSL (2)</th>
     <th>RF Switch Control Pins (3)</th>
     <th>LED(s)</th>
+    <th>Hardware Flow Control</th>
   </tr>
 </thead>
 <tbody>
@@ -23,6 +24,7 @@
     <td>No</td>
     <td>N/A</td>
     <td>DIO_6 (Red)<br>DIO_7 (Green)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>TI LAUNCHXL-CC1352P-2</td>
@@ -32,6 +34,7 @@
     <td>No</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA<br>DIO_30: Sub-1GHz</td>
     <td>DIO_6 (Red)<br>DIO_7 (Green)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Electrolama zzh</td>
@@ -41,6 +44,7 @@
     <td>No</td>
     <td>N/A</td>
     <td>DIO_7 (Pink)</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Electrolama zzhp-lite</td>
@@ -50,6 +54,7 @@
     <td>Yes</td>
     <td>DIO_5: 20dBm PA ??<br>DIO_6: 2.4GHz ??<br></td>
     <td>DIO_7 (Pink)</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Electrolama zzhp</td>
@@ -59,6 +64,7 @@
     <td>Yes</td>
     <td>DIO_5: 20dBm PA ??<br>DIO_6: 2.4GHz ??</td>
     <td>DIO_7 (Pink)</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Electrolama zoe2</td>
@@ -68,6 +74,7 @@
     <td>No</td>
     <td>DIO_5: 20dBm PA ??<br>DIO_6: 2.4GHz ??</td>
     <td>DIO_7 (Pink)</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Slaesh's CC2652RB stick</td>
@@ -77,6 +84,7 @@
     <td>Yes</td>
     <td>N/A</td>
     <td>DIO_7 (Blue)</td>
+    <td>?</td>
   </tr>
   <tr>
     <td><a href="https://zig-star.com">ZigStar Stick v4</a></td>
@@ -86,6 +94,7 @@
     <td>Only for CH340C ver.</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_6 (Green)<br>DIO_7 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>CircuitSetup.us Zigbee Stick</a></td>
@@ -95,6 +104,7 @@
     <td>No</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_6 (Green)<br>DIO_7 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Tube's CC2652P2 USB Coordinator<br></td>
@@ -104,6 +114,7 @@
     <td>N/A</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>N/A</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Tube's Zigbee Gateways (CC2652P2 variant)<br></td>
@@ -113,6 +124,7 @@
     <td>N/A</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>N/A</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Tube's Zigbee PoE (Power Over Ethernet) Serial Coordinator (CC2652P2 variant)<br></td>
@@ -122,6 +134,7 @@
     <td>N/A</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>N/A</td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Egony Stick V4<br>(Ebyte ver.)</td>
@@ -131,6 +144,7 @@
     <td>Yes<br>(from Rev.2.0)</td>
     <td>DIO_5: 20dBm PA<br>DIO_6: 2.4GHz</td>
     <td>DIO_8 (Green)<br>DIO_7 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Egony Stick V4<br>(RFSTAR ver.)</td>
@@ -140,6 +154,7 @@
     <td>Yes</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_7 (Green)<br>DIO_6 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>cod.m Zigbee CC2652P RPi Module</td>
@@ -149,6 +164,7 @@
     <td>Yes</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_7 (Green)<br>DIO_6 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>Gio-dot Z-Bee Duo with CC2652P</td>
@@ -158,6 +174,7 @@
     <td>Yes<br>(from Rev.2.0)</td>
     <td>DIO_5: 20dBm PA<br>DIO_6: 2.4GHz</td>
     <td>DIO_8 (Green)<br>DIO_7 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
     <td>cyijun <a href="https://github.com/cyijun/OpenZ3Gateway">OpenZ3Gateway</a></td>
@@ -167,15 +184,17 @@
     <td>No</td>
     <td>DIO_28: 2.4Ghz<br>DIO_29: 20dBm PA</td>
     <td>DIO_7 (Green)<br>DIO_6 (Red)<br></td>
+    <td>?</td>
   </tr>
   <tr>
-    <td>SONOFF Zigbee 3.0 USB Dongle Plus</td>
+    <td>SONOFF Zigbee 3.0 USB Dongle Plus by ITead</td>
     <td>CC2652P</td>
     <td>CC1352P2_CC2652P_launchpad_*.zip</td>
     <td>?</td>
     <td>No</td>
+    <td>DIO_29: 20dBm PA</td>
     <td>?</td>
-    <td>N/A</td>
+    <td>DIO13: TX<br>DIO12:RC<br>DIO19: CTS<br>DIO18: RTS</td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Update README.md adding info on RF and RFS/CTS Hardware Flow Control pins on Zigbee 3.0 USB Dongle Plus adapter as per https://sonoff.tech/wp-content/uploads/2021/09/Zigbee-3.0-USB-dongle-plus-firmware-flashing-1-1.docx 

_UART Peripheral = Any(UART0)
TX Pin = DIO13/4 (XDS110 UART)
RC Pin = DIO12/3 (XDS110 UART)
CTS Pin = DIO19/19 (Header)
RTS Pin = DIO18/36 (Header)_


Also the observation from @chiakikato who checked RF traces for PA on it and posted his findings in https://github.com/Koenkk/zigbee2mqtt/discussions/8840#discussioncomment-1550021


_Originally posted by @chiakikato in https://github.com/Koenkk/zigbee2mqtt/discussions/8840#discussioncomment-1550021_

> I check the trace of SONOFF.
> DIO_29: 20dBm PA is connected. but DIO_28: is N.C.
>it uses PE4259 or compatible's SC-70 6P RF switch which does not have 3 RF signals input for 2.4GHz 5dBm, 2.4GHz 20dBm and SubGHz.  
>I think it is a reason DIO_28 is not connected.

_Originally posted by @chiakikato in https://github.com/Koenkk/zigbee2mqtt/discussions/8840#discussioncomment-1550148_

> I set RF switch control as HIGH by external hardwired method and got -22~-19dBm worth result.
> It means the firmware's RF switch control has no problem.
> SONOFF RF antenna and/or RF circuit need to be doubted.  

As well as set info on LED for this Sonoff dongle to "?" since the board does at least have a LED on it so "No" should not be true there (or?), see pictures and description of board components at https://itead.cc/product/sonoff-zigbee-3-0-usb-dongle-plus/ which does list "Reserved LED IO"

![image](https://user-images.githubusercontent.com/6320001/139835759-8ee669d1-63f1-438a-bc09-d09453835ccb.png)
