### PR TITLE
SONOFF Zigbee 3.0 USB Dongle Plus by ITead do support Auto BSL

### DIFF
--- a/coordinator/Z-Stack_3.x.0/bin/README.md
+++ b/coordinator/Z-Stack_3.x.0/bin/README.md
@@ -191,7 +191,7 @@
     <td>CC2652P</td>
     <td>CC1352P2_CC2652P_launchpad_*.zip</td>
     <td>?</td>
-    <td>No</td>
+    <td>Yes</td>
     <td>DIO_29: 20dBm PA</td>
     <td>?</td>
     <td>DIO13: TX<br>DIO12:RC<br>DIO19: CTS<br>DIO18: RTS</td>


### PR DESCRIPTION
UPDATE! Auto BSL works on ITead's Sonoff Zigbee 3.0 USB Dongle Plus using c2538-bsl with patch -> https://github.com/JelmerT/cc2538-bsl/pull/114

The back-story is that several other Home Assistant community members have tested Sonoff provided uartLog.py script which seems to confirm "Auto BSL" is working even if it does not currently work with the current version of cc2538-bsl and llama-bsl.

https://community.home-assistant.io/t/itead-sonoff-zigbee-3-0-usb-dongle-plus-adapter-based-on-texas-instruments-cc2652p/340705/45

https://community.home-assistant.io/t/itead-sonoff-zigbee-3-0-usb-dongle-plus-adapter-based-on-texas-instruments-cc2652p/340705/96

Anyway, I have now also myself confirmed that running the attached `uartLog.py` script from [Sonoff docx](https://sonoff.tech/wp-content/uploads/2021/09/Zigbee-3.0-USB-dongle-plus-firmware-flashing-1-1.docx) part as published in ITead's [HOW TO FLASH FIRMWARE TO CC2652P](https://sonoff.tech/product-review/zigbee-3-0-usb-dongle-plus/) instructions do indeed make ITead's Sonoff Zigbee 3.0 Plus Dongle automatically enter bootloader mode and after running that script just to get into BSL mode I could flash it directly using cc2538-bsl.py and llama-bsl.py scripts without having open the enclosure and pressing the BTL button which of course can be very convenient.

Copy of attached script from ITead/Sonoff: [uartLog.zip](https://github.com/Koenkk/Z-Stack-firmware/files/7504776/uartLog.zip)

This is code in Sonoff provided uartLog.py script that already works to enters the bootloader using Auto-BSL software reset:

```
def enterBoot(serialPort, delay=False):
    # delay is a workaround for bugs with the most common auto reset
    # circuit and Windows, if the EN pin on the dev board does not have
    # enough capacitance.
    # 如果开发板上EN管脚没有足够电容
    last_error = None

    # issue reset-to-bootloader:
    # RTS = either CH_PD/EN or nRESET (both active low = chip in reset
    # DTR = GPIO0 (active low = boot to flasher)
    #
    # DTR & RTS are active low signals,
    # ie True = pin @ 0V, False = pin @ VCC.
    setDTRState(serialPort, False)  # IO0=HIGH
    # setDTRState(serialPort, True)   # IO0=LOW
    setRTSState(serialPort, True)  # EN=LOW, chip in reset
    time.sleep(0.1)
    if delay:
        # Some chips are more likely to trigger the esp32r0
        # watchdog reset silicon bug if they're held with EN=LOW
        # for a longer period
        time.sleep(1.2)

    setDTRState(serialPort, True)  # IO0=LOW
    setRTSState(serialPort, False)  # EN=HIGH, chip out of reset
    if delay:
        # Sleep longer after reset.
        # This workaround only works on revision 0 ESP32 chips,
        # it exploits a silicon bug spurious watchdog reset.
        time.sleep(0.4)  # allow watchdog reset to occur
    time.sleep(1)

    setDTRState(serialPort, False)  # IO0=HIGH, done
    setRTSState(serialPort, False)
    time.sleep(1)

    return last_error
```

_So it looks like both pins are active low, and RTS is connected to reset and DTR is connected to the bootloader pin. Which should be the same as in the standard configuration in this script._
_So the only difference I'm seeing is the extra delays in their script._
_Try adding some delays in the same spots, and see if that makes it work._


PS: The probable reason why does not yet work in cc2538-bsl is needed extra delays in the script, see -> https://github.com/JelmerT/cc2538-bsl/issues/113