### PR TITLE
Fix tXPower set to 20, when hardcoded to 9

### DIFF
--- a/coordinator/Z-Stack_3.x.0/firmware.patch
+++ b/coordinator/Z-Stack_3.x.0/firmware.patch
@@ -1708,7 +1708,7 @@ index 2725d0f8..af3fc593 100644
 +++ b/workspace/znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang/znp.syscfg
 @@ -4,6 +4,10 @@
   * @cliArgs --board "/ti/boards/CC1352P_2_LAUNCHXL" --rtos "tirtos7" --product "simplelink_cc13xx_cc26xx_sdk@7.10.00.98"
-  * @versions {"tool":"1.15.0+2826"}
+  * @versions {"tool":"1.16.1+2960"}
   */
 +scripting.excludeFromBuild("ti_devices_config.c");
 +scripting.excludeFromBuild("ti_radio_config.c");

--- a/coordinator/Z-Stack_3.x.0/firmware.patch
+++ b/coordinator/Z-Stack_3.x.0/firmware.patch
@@ -1740,7 +1740,7 @@ index 2725d0f8..af3fc593 100644
  zstack.touchlink.$name                       = "ti_zstack_touchlink_zstack_touchlink0";
  zstack.pm.$name                              = "ti_zstack_pm_zstack_pm0";
  zstack.rf.$name                              = "ti_zstack_rf_zstack_rf0";
-+zstack.rf.txPower                            = "20";
++zstack.rf.txPower                            = "9";
  zstack.rf.radioConfig.$name                  = "ti_devices_radioconfig_settings_ieee_15_40";
  zstack.rf.radioConfig.codeExportConfig.$name = "ti_devices_radioconfig_code_export_param0";
  zstack.rf.coexSettings.$name                 = "ti_zstack_rf_zstack_coex_mod0";


### PR DESCRIPTION
There's no point in setting the txPower to 20 in our config, when in fact
the txPower is set to 9 via a hardcoded define in this very same patch.
    
Instead, ensure that the generated files have the proper txPower defined
so that the `ti_zstack_config.h` [0] can set it properly internally.
    
[0]: source/ti/zstack/.meta/templates/ti_zstack_config.h.xdt:463

While here, do a boyscout fix on the syscfg version to make the patch apply cleanly. This version matches to what is part of the sdk/css as described in `COMPILE.md`.