### PR TITLE
Match SDK and patch line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -text

--- a/coordinator/Z-Stack_3.x.0/COMPILE.md
+++ b/coordinator/Z-Stack_3.x.0/COMPILE.md
@@ -7,21 +7,21 @@
 ## Compiling
 1. Create a folder called `workspace` in the folder where the SDK is installed. In the SDK installation folder you should see files like `Makefile` and `license_simplelink_cc13xx_cc26xx_sdk_7_10_00_98.txt`.
 1. Start Code Composer Studio, it will ask you to select a workspace folder, select the `workspace` folder you created in the previous step.
-1. Go to *File -> Import -> Code Composer Studio -> CCS Projects -> Select* search-directory: `simplelink_cc13xx_cc26xx_sdk_7_10_00_98/examples/rtos`. 
+1. Go to *File -> Import -> Code Composer Studio -> CCS Projects -> Select* search-directory: `simplelink_cc13xx_cc26xx_sdk_7_10_00_98/examples/rtos`.
 1. Select:
-    - `znp_CC26X2R1_LAUNCHXL_tirtos7_ticlang`
     - `znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang`
-    - `znp_LP_CC2652RB_tirtos7_ticlang`
+    - `znp_CC26X2R1_LAUNCHXL_tirtos7_ticlang`
     - `znp_LP_CC1352P7_4_tirtos7_ticlang`
     - `znp_LP_CC2652R7_tirtos7_ticlang`
+    - `znp_LP_CC2652RB_tirtos7_ticlang`
 1. Press *Finish*.
 1. In Code Composer Studio, expand the 5 projects and for each open `znp.syscfg`, expand `Power Management` and change `Minimal Poll Period (ms)` to `1000`, change it back to `100` immediately and save the file.
 1. Copy `firmware.patch` to the SDK installation folder, open a Git Bash in this folder and apply the patch using `git apply firmware.patch --ignore-space-change`.
 1. Build the 5 projects; right click -> *Build project*.
     - **Important:** by default the **launchpad** variant of the CC1352P2_CC2652P (= `znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang`) is build. To build the **other** variant comment `#define LAUNCHPAD_CONFIG 1` in `preinclude.h` (located under `Stack/Config/`), don't forget to save.
 1. Once finished, the firmware can be found under `znp_*_tirtos7_ticlang/default/znp_*_tirtos7_ticlang.hex`
-    - `znp_CC26X2R1_LAUNCHXL_tirtos7_ticlang.hex` -> CC2652R
-    - `znp_LP_CC2652RB_tirtos7_ticlang.hex` -> CC2652RB
-    - `znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang.hex` -> CC1352P-2 and CC2652P
-    - `znp_LP_CC1352P7_4_tirtos7_ticlang.hex` -> CC1352P7
-    - `znp_LP_CC2652R7_tirtos7_ticlang.hex` -> CC2652R7
+    - `znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang.hex` -> CC1352P-2 and CC2652P based boards
+    - `znp_CC26X2R1_LAUNCHXL_tirtos7_ticlang.hex` -> CC2652R based boards
+    - `znp_LP_CC1352P7_4_tirtos7_ticlang.hex` -> CC1352P7 based boards
+    - `znp_LP_CC2652R7_tirtos7_ticlang.hex` -> CC2652R7 based boards
+    - `znp_LP_CC2652RB_tirtos7_ticlang.hex` -> CC2652RB based boards

--- a/coordinator/Z-Stack_3.x.0/firmware.patch
+++ b/coordinator/Z-Stack_3.x.0/firmware.patch
@@ -42,8 +42,6 @@ Subject: [PATCH 1/1] Own changes
  .../znp.syscfg                                |   6 +-
  36 files changed, 1363 insertions(+), 29 deletions(-)
  create mode 100644 source/ti/zstack/stack/Config/preinclude.h
- mode change 100644 => 100755 source/ti/zstack/stack/af/af.c
- mode change 100644 => 100755 source/ti/zstack/stack/nwk/nwk_globals.c
  create mode 100644 source/ti/zstack/stack/nwk/nwk_util.c
  create mode 100644 workspace/znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang/ti_devices_config.c
  create mode 100644 workspace/znp_CC1352P_2_LAUNCHXL_tirtos7_ticlang/ti_drivers_config.h
@@ -502,9 +500,7 @@ index 00000000..a50a178c
 +    #endif
 +#endif
 diff --git a/source/ti/zstack/stack/af/af.c b/source/ti/zstack/stack/af/af.c
-old mode 100644
-new mode 100755
-index 12512a39..4298e709
+index 12512a39..4298e709 100644
 --- a/source/ti/zstack/stack/af/af.c
 +++ b/source/ti/zstack/stack/af/af.c
 @@ -433,10 +433,18 @@ void afIncomingData( aps_FrameFormat_t *aff, zAddrType_t *SrcAddress, uint16_t S
@@ -541,9 +537,7 @@ index 12512a39..4298e709
        // Save original endpoint
        uint8_t endpoint = aff->DstEndPoint;
 diff --git a/source/ti/zstack/stack/nwk/nwk_globals.c b/source/ti/zstack/stack/nwk/nwk_globals.c
-old mode 100644
-new mode 100755
-index a0acd954..7b12a23c
+index a0acd954..7b12a23c 100644
 --- a/source/ti/zstack/stack/nwk/nwk_globals.c
 +++ b/source/ti/zstack/stack/nwk/nwk_globals.c
 @@ -91,10 +91,10 @@


### PR DESCRIPTION
Simple MR to ensure line-endings match the expected formats. While `git apply --ignore-space-change` makes this issue also go away, it's still a bit nasty. So lets match what the SDK expects to have cleaner patches and commits.

While here, a boyscout commit that cleans up the documentation a little bit.