### PR TITLE
docs(router): fix link to Coordinator Firmware README.md

### DIFF
--- a/router/Z-Stack_3.x.0/README.md
+++ b/router/Z-Stack_3.x.0/README.md
@@ -1,7 +1,7 @@
 # Z-Stack 3.x.0 router firmwares
 
 ## What firmware to pick for my device?
-Same logic as the coordinator firmware applies. See [README.md of the coordinator firmware](../../../coordinator/Z-Stack_3.x.0/bin/README.md).
+Same logic as the coordinator firmware applies. See [README.md of the coordinator firmware](../../coordinator/Z-Stack_3.x.0/README.md).
 
 ## Pairing
 After reflashing the router will automatically pair.


### PR DESCRIPTION
Files got moved via commit d4eff4f, but links were not adapted in router's README.md

The second line, it shows as change in the diff is a "new line" that got added by GitHub's web editor...